### PR TITLE
Updated deploy location for S3 bucket

### DIFF
--- a/.github/workflows/deploy-s3-master.yml
+++ b/.github/workflows/deploy-s3-master.yml
@@ -30,5 +30,5 @@ jobs:
         run: bundle exec jekyll build
       - name: Deploy static site to production S3 bucket
         run: |
-          aws s3 sync ./_site/ s3://standardshub --delete
+          aws s3 sync ./_site/ s3://www.standardshub.io --delete
 


### PR DESCRIPTION
A new S3 bucket was created to allow for the www.standardshub.io custom domain